### PR TITLE
feat: Implement handling of empty sides in Awale game

### DIFF
--- a/AwaleEnv/viewer.py
+++ b/AwaleEnv/viewer.py
@@ -1,0 +1,148 @@
+from IPython.display import SVG
+from typing import List, Tuple
+
+
+def generate_seed_positions(num_seeds: int) -> List[Tuple[int, int]]:
+    """
+    Generate positions for seeds based on count.
+    """
+    if num_seeds <= 4:
+        return [(0, -10), (-10, 0), (10, 0), (0, 10)][:num_seeds]
+    elif num_seeds <= 8:
+        return [
+            (0, -10),
+            (-10, -10),
+            (10, -10),
+            (-10, 0),
+            (10, 0),
+            (-10, 10),
+            (0, 10),
+            (10, 10),
+        ][:num_seeds]
+    else:
+        return [
+            (0, -12),
+            (-6, -10),
+            (6, -10),
+            (-10, -6),
+            (10, -6),
+            (-12, 0),
+            (12, 0),
+            (-10, 6),
+            (10, 6),
+            (-6, 10),
+            (6, 10),
+            (0, 12),
+        ][:num_seeds]
+
+
+def generate_pit_svg(cx: int, cy: int, seeds: int) -> str:
+    """
+    Generate SVG for a single pit and its seeds.
+    """
+    pit_svg = [
+        f"""
+    <g>
+        <circle cx="{cx}" cy="{cy}" r="30" fill="#E5BA73" stroke="#7D5A50" stroke-width="3"/>"""
+    ]
+
+    if seeds > 0:
+        positions = generate_seed_positions(seeds)
+        seeds_svg = [
+            f'        <circle cx="{cx + dx}" cy="{cy + dy}" r="6" fill="#8B4513"/>'
+            for dx, dy in positions
+        ]
+        pit_svg.extend(seeds_svg)
+
+    # Add seed count text
+    pit_svg.append(
+        f'        <text x="{cx}" y="{cy+5}" font-family="Arial" '
+        f'font-size="16" fill="#7D5A50" text-anchor="middle">{seeds}</text>'
+    )
+    pit_svg.append("    </g>")
+
+    return "\n".join(pit_svg)
+
+
+def generate_svg_content(board: List[int], scores: List[int]) -> str:
+    """
+    Generate the SVG content as a string.
+    """
+    # Define pit positions
+    pit_positions = [
+        (500, 150),
+        (420, 150),
+        (340, 150),
+        (260, 150),
+        (180, 150),
+        (100, 150),  # Top row
+        (100, 250),
+        (180, 250),
+        (260, 250),
+        (340, 250),
+        (420, 250),
+        (500, 250),  # Bottom row
+    ]
+
+    # Generate all pits
+    pits_svg = [
+        generate_pit_svg(cx, cy, seeds) for (cx, cy), seeds in zip(pit_positions, board)
+    ]
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
+    <!-- Background -->
+    <rect width="600" height="400" fill="#F9F5EB" rx="20"/>
+    
+    <!-- Board -->
+    <rect x="50" y="100" width="500" height="200" fill="#B4846C" rx="15"/>
+    
+    <!-- Pits and Seeds -->
+    {''.join(pits_svg)}
+    
+    <!-- Player Labels and Scores -->
+    <!-- Player 2 -->
+    <rect x="220" y="50" width="160" height="35" fill="#7D5A50" rx="10"/>
+    <text x="230" y="75" font-family="Arial" font-size="24" fill="#F9F5EB" font-weight="bold">Player 2</text>
+    
+    <!-- Player 2 Score -->
+    <rect x="500" y="50" width="60" height="35" fill="#7D5A50" rx="10"/>
+    <text x="515" y="75" font-family="Arial" font-size="24" fill="#F9F5EB" font-weight="bold">{scores[1]}</text>
+    
+    <!-- Player 1 -->
+    <rect x="220" y="315" width="160" height="35" fill="#7D5A50" rx="10"/>
+    <text x="230" y="340" font-family="Arial" font-size="24" fill="#F9F5EB" font-weight="bold">Player 1</text>
+    
+    <!-- Player 1 Score -->
+    <rect x="500" y="315" width="60" height="35" fill="#7D5A50" rx="10"/>
+    <text x="515" y="340" font-family="Arial" font-size="24" fill="#F9F5EB" font-weight="bold">{scores[0]}</text>
+</svg>"""
+
+
+def render_board(board: List[int], scores: List[int]) -> SVG:
+    """
+    Render the Awale board state as an SVG displayable in a Jupyter notebook.
+
+    Args:
+        board: List of 12 integers representing seeds in each pit
+        scores: List of 2 integers representing player scores
+
+    Returns:
+        IPython.display.SVG: SVG object for notebook display
+    """
+    svg_content = generate_svg_content(board, scores)
+    return SVG(data=svg_content)
+
+
+def save_board_svg(board: List[int], scores: List[int], filename: str) -> None:
+    """
+    Save the board state as an SVG file.
+
+    Args:
+        board: List of 12 integers representing seeds in each pit
+        scores: List of 2 integers representing player scores
+        filename: Name of the file to save
+    """
+    svg_content = generate_svg_content(board, scores)
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(svg_content)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -26,9 +26,106 @@ def test_initial_state(initial_state):
     assert jnp.array_equal(initial_state.score, jnp.zeros(2, dtype=jnp.int8))
 
 
-def test_step_valid_move(initial_state, game):
-    state, reward, done, info = game.step(initial_state, 0)
+def test_step_valid_move(game, initial_state):
+    current_player = initial_state.current_player
+    state, reward, done = game.step(initial_state, 0)
     assert jnp.array_equal(
-        state, jnp.array([0, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4], dtype=jnp.int8)
+        state.board, jnp.array([0, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4], dtype=jnp.int8)
     )
     assert not done
+    assert state.current_player != current_player
+
+
+def test_capture_after_move(game, initial_state):
+    initial_state = State(
+        board=jnp.array([4, 4, 4, 4, 4, 3, 2, 2, 3, 2, 4, 4], dtype=jnp.int8),
+        action_space=initial_state.action_space,
+        key=initial_state.key,
+        score=initial_state.score,
+        current_player=0,
+    )
+
+    state, reward, done = game.step(initial_state, 3)
+    assert jnp.array_equal(
+        state.board, jnp.array([4, 4, 4, 0, 5, 4, 0, 0, 3, 2, 4, 4], dtype=jnp.int8)
+    )
+    assert jnp.array_equal(state.score, jnp.array([6, 0], dtype=jnp.int8))
+
+
+def test_game_end_by_score(game, initial_state):
+    initial_state = State(
+        board=jnp.array([1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0], dtype=jnp.int8),
+        action_space=initial_state.action_space,
+        key=initial_state.key,
+        score=jnp.array([24, 23], dtype=jnp.int8),
+        current_player=0,
+    )
+    state, reward, done = game.step(initial_state, 0)
+    assert done
+    assert reward > 99
+    assert state.current_player == 0
+
+
+def test_game_end_by_empty_side(game, initial_state):
+    initial_state = State(
+        board=jnp.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=jnp.int8),
+        action_space=initial_state.action_space,
+        key=initial_state.key,
+        score=initial_state.score,
+        current_player=0,
+    )
+
+    game.state = jnp.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=jnp.int8)
+    game.current_player = 0
+    state, reward, done = game.step(initial_state, 5)
+    assert done
+    assert state.current_player == 1
+
+
+def test_action_space_changes(game, initial_state):
+    initial_state = State(
+        board=jnp.array([4, 0, 4, 0, 4, 0, 3, 3, 0, 3, 0, 3], dtype=jnp.int8),
+        action_space=jnp.array([0, 2, 4], dtype=jnp.int8),
+        key=initial_state.key,
+        score=initial_state.score,
+        current_player=0,
+    )
+    state, reward, done = game.step(initial_state, 0)
+    assert jnp.array_equal(state.action_space, jnp.array([6, 7, 9, 11], dtype=jnp.int8))
+    assert state.current_player
+
+
+def test_reset(game, initial_state):
+    game.step(initial_state, 0)
+    state = game.reset(PRNGKey(0))
+    assert jnp.array_equal(state.board, jnp.array([4] * 12, dtype=jnp.int8))
+    assert jnp.array_equal(state.score, jnp.zeros(2, dtype=jnp.int8))
+    assert state.current_player == 0
+
+
+def test_render(game, initial_state):
+    try:
+        game.render(initial_state)
+    except Exception as e:
+        pytest.fail(f"render() raised {type(e).__name__} unexpectedly!")
+
+
+def test_render_other_state(game, initial_state):
+    initial_state = State(
+        board=jnp.array([4, 0, 4, 0, 4, 0, 3, 3, 0, 3, 0, 3], dtype=jnp.int8),
+        action_space=initial_state.action_space,
+        key=initial_state.key,
+        score=jnp.array([24, 23], dtype=jnp.int8),
+        current_player=0,
+    )
+    try:
+        game.render(initial_state)
+    except Exception as e:
+        pytest.fail(f"render() raised {type(e).__name__} unexpectedly!")
+
+
+def test_repr(game, initial_state):
+    try:
+        game.__repr__()
+    except Exception as e:
+        pytest.fail(f"render() raised {type(e).__name__} unexpectedly!")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,16 +1,9 @@
 import pytest
 import jax.numpy as jnp
 from jax import random
-import chex
-from typing import NamedTuple
 
-from AwaleEnv.utils import (
-    State,
-    distribute_seeds,
-    capture_seeds,
-    update_game_state,
-    get_action_space,
-)
+
+from AwaleEnv.utils import State, distribute_seeds, capture_seeds, update_game_state
 
 
 @pytest.fixture
@@ -38,11 +31,12 @@ def test_distribute_seeds():
     board = jnp.array([4] * 12, dtype=jnp.int8)
     current_pit = jnp.int8(0)
     seeds = board[current_pit]
+    board = board.at[0].set(0)
 
     new_board, last_pit = distribute_seeds(board, current_pit, seeds)
     expected = jnp.array([0, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4], dtype=jnp.int8)
     assert (new_board == expected).all()
-    assert last_pit == 3
+    assert last_pit == 4
 
 
 def test_capture_seeds():
@@ -52,7 +46,7 @@ def test_capture_seeds():
 
     new_board, captured = capture_seeds(board, last_pit, current_player)
     expected = jnp.array([4, 4, 4, 4, 4, 3, 0, 0, 0, 0, 4, 4], dtype=jnp.int8)
-    assert (new_board == expected).all()
+    assert jnp.array_equal(new_board, expected)
     assert captured == 9
 
 
@@ -61,71 +55,35 @@ def test_update_game_state_score_end():
     scores = jnp.array([24, 23], dtype=jnp.int8)
     current_player = jnp.int8(0)
 
-    (
-        new_board,
-        new_scores,
-        new_player,
-        done,
-        reward,
-        winner,
-        action_space,
-    ) = update_game_state(board, scores, current_player)
+    (board, score, done, reward, winner) = update_game_state(
+        board, scores, current_player
+    )
     assert done
     assert reward == 100  # Winner reward
     assert winner == 0
 
 
 def test_update_game_state_empty_side():
-    board = jnp.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1], dtype=jnp.int8)
+    board = jnp.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1], dtype=jnp.int8)
     scores = jnp.array([10, 10], dtype=jnp.int8)
     current_player = jnp.int8(0)
 
-    (
-        new_board,
-        new_scores,
-        new_player,
-        done,
-        reward,
-        winner,
-        action_space,
-    ) = update_game_state(board, scores, current_player)
+    (new_board, new_scores, done, reward, winner) = update_game_state(
+        board, scores, current_player
+    )
     assert done
-    assert (new_board == jnp.zeros_like(board)).all()
+    assert jnp.array_equal(new_board, jnp.zeros_like(board))
     assert new_scores[1] > new_scores[0]  # Player 1 should win
 
 
-def test_get_action_space():
-    player_0_actions = get_action_space(jnp.int8(0))
-    player_1_actions = get_action_space(jnp.int8(1))
-
-    assert (player_0_actions == jnp.array([0, 1, 2, 3, 4, 5], dtype=jnp.int8)).all()
-    assert (player_1_actions == jnp.array([6, 7, 8, 9, 10, 11], dtype=jnp.int8)).all()
-
-
-def test_switch_player():
-    board = jnp.array([4] * 12, dtype=jnp.int8)
+def test_update_game_state_switch_player():
+    board = jnp.array([1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0], dtype=jnp.int8)
     scores = jnp.array([0, 0], dtype=jnp.int8)
     current_player = jnp.int8(0)
 
-    (
-        new_board,
-        new_scores,
-        new_player,
-        done,
-        reward,
-        winner,
-        action_space,
-    ) = update_game_state(board, scores, current_player)
-    assert new_player == 1
-    assert not done
-    assert reward == 0
-    assert (action_space == jnp.array([6, 7, 8, 9, 10, 11], dtype=jnp.int8)).all()
-
-
-# Helper function to check array equality with proper type checking
-def check_array_equal(arr1, arr2):
-    return (
-        isinstance(arr1, chex.Array)
-        and isinstance(arr2, chex.Array)
-        and (arr1 == arr2).all()
+    (new_board, new_scores, done, reward, winner) = update_game_state(
+        board, scores, current_player
     )
+    assert done == False
+    assert winner == 1
+    assert jnp.array_equal(new_board, board)


### PR DESCRIPTION
      
This change implements the logic for handling the case when one player's 
side is empty in the Awale game. When a player's side is empty, all the 
remaining seeds in that player's pits are awarded to the other player.
      
The changes include:
- Implement the `handle_empty_side` function to handle this case
- Update the `is_player_side_empty` function to check if a player's side
  is empty
- Add type annotations for the function parameters and return types
- Update the tests to cover the case of an empty side