### PR TITLE
feat: Implement AwaleNetwork model with Equinox

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@
 - https://medium.com/@samina.amin/deep-q-learning-dqn-71c109586bae
 - https://medium.com/geekculture/actor-critic-implementing-actor-critic-methods-82efb998c273
 - https://github.com/tsmatz/reinforcement-learning-tutorials/blob/master/03-actor-critic.ipynb
+- https://docs.kidger.site/equinox/

--- a/awale/env.py
+++ b/awale/env.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
-from jax import jit, lax
-from typing import NamedTuple, Tuple, Dict
+from jax import jit
+from typing import Tuple
 from awale.utils import (
     distribute_seeds,
     capture_seeds,
@@ -10,8 +10,6 @@ from awale.utils import (
     calculate_reward,
 )
 from awale.viewer import save_board_svg
-import chex
-from typing_extensions import TypeAlias
 import jax.random as random
 from jax.random import PRNGKey
 

--- a/awale/utils.py
+++ b/awale/utils.py
@@ -1,8 +1,6 @@
-from functools import partial
-
 import jax.numpy as jnp
 from jax import jit, lax
-import jax
+
 from typing import NamedTuple, Tuple
 
 import chex

--- a/model.py
+++ b/model.py
@@ -1,0 +1,107 @@
+import jax
+import equinox as eqx
+import equinox.nn as nn
+import jax.numpy as jnp
+from typing import Any, List
+
+
+class AwaleNetwork(eqx.Module):
+    state_encoder: List[Any]
+    action_embedding: nn.Embedding
+    combine: List[Any]
+
+    def __init__(self, key: jax.random.PRNGKey):
+        super().__init__()
+        keys = jax.random.split(key, 7)
+
+        # Input layer for state representation (12 pits + 2 scores)
+        self.state_encoder = [
+            nn.Linear(14, 64, key=keys[0]),  # 12 pits + 2 scores -> 64
+            nn.Linear(64, 128, key=keys[1]),  # 64 -> 128
+            jax.nn.relu,
+            nn.Linear(128, 64, key=keys[2]),  # 128 -> 64
+            jax.nn.relu,
+        ]
+
+        # Action embedding layer
+        self.action_embedding = nn.Embedding(
+            12, 32, key=keys[3]
+        )  # Can embed any action index 0-11
+
+        # Final layers to combine state and action information
+        self.combine = [
+            nn.Linear(96, 64, key=keys[4]),  # 64 (state) + 32 (action) = 96
+            jax.nn.relu,
+            nn.Linear(64, 32, key=keys[5]),
+            jax.nn.relu,
+            nn.Linear(32, 1, key=keys[6]),
+        ]
+
+    def apply_linear_batch(self, layer: nn.Linear, x: jnp.ndarray) -> jnp.ndarray:
+        """Apply a linear layer to batched input, handling bias broadcasting correctly."""
+        batch_size = x.shape[0]
+        # Reshape input to (batch_size, input_dim)
+        reshaped_x = x.reshape(batch_size, -1)
+        # Apply weight matrix
+        output = jnp.matmul(reshaped_x, layer.weight.T)
+        # Add bias with correct broadcasting
+        output = output + layer.bias[None, :]
+        return output
+
+    def __call__(
+        self, game_state: jnp.ndarray, valid_actions: jnp.ndarray, score: jnp.ndarray
+    ) -> jnp.ndarray:
+        """
+        Args:
+            game_state: Array of shape (12,) representing the game board
+            valid_actions: Array of valid action indices
+            score: Array of shape (2,) containing scores for both players
+        Returns:
+            Array of shape (num_valid_actions,) containing value predictions
+        """
+        # Handle empty actions case
+        if valid_actions.size == 0:
+            return jnp.array([])
+
+        # Encode state
+        state_features = jnp.concatenate([game_state, score])  # Shape: (14,)
+
+        # Pass through state encoder
+        state_features = state_features
+        for layer in self.state_encoder:
+            if isinstance(layer, nn.Linear):
+                state_features = layer(state_features)
+            else:
+                state_features = layer(state_features)
+
+        # Get action embeddings using vmap
+        action_features = jax.vmap(self.action_embedding)(
+            valid_actions
+        )  # Shape: (num_actions, 32)
+
+        # Broadcast state features to match number of actions
+        num_actions = valid_actions.shape[0]
+        state_features = jnp.tile(
+            state_features[None, :], (num_actions, 1)
+        )  # Shape: (num_actions, 64)
+
+        # Combine features
+        combined = jnp.concatenate(
+            [state_features, action_features], axis=1
+        )  # Shape: (num_actions, 96)
+
+        # Pass through combine layers
+        values = combined
+        for layer in self.combine:
+            if isinstance(layer, nn.Linear):
+                values = self.apply_linear_batch(layer, values)
+            else:
+                values = layer(values)
+
+        return values.squeeze(-1)  # Shape: (num_actions,)
+
+
+# Helper function for initialization
+def init_network(key: jax.random.PRNGKey = jax.random.PRNGKey(0)) -> AwaleNetwork:
+    """Initialize the network with default parameters."""
+    return AwaleNetwork(key)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,167 @@
+import pytest
+import jax
+import jax.numpy as jnp
+import equinox as eqx
+from typing import List, Tuple
+import numpy as np
+from model import AwaleNetwork
+
+
+@pytest.fixture
+def network():
+    """Create a fresh network instance for each test."""
+    key = jax.random.PRNGKey(0)  # Fixed seed for reproducibility
+    return AwaleNetwork(key)
+
+
+@pytest.fixture
+def sample_game_state():
+    """Create a sample game state."""
+    # 12 pits with random seeds (0-4) + 2 scores
+    key = jax.random.PRNGKey(1)
+    pits = jax.random.randint(key, (12,), 0, 5)
+    return pits
+
+
+@pytest.fixture
+def sample_score():
+    """Create a sample score."""
+    return jnp.array([0, 0])
+
+
+def test_network_initialization(network):
+    """Test that the network initializes with correct structure."""
+    assert isinstance(network, AwaleNetwork)
+    assert len(network.state_encoder) == 5
+    assert isinstance(network.action_embedding, eqx.nn.Embedding)
+    assert len(network.combine) == 5
+
+
+def test_state_encoder_dimensions(network, sample_game_state, sample_score):
+    """Test the dimensions of state encoder output."""
+    state_features = jnp.concatenate([sample_game_state, sample_score])
+
+    # Pass through state encoder layers
+    for layer in network.state_encoder:
+        state_features = layer(state_features)
+
+    assert state_features.shape == (64,)
+
+
+def test_action_embedding_dimensions(network):
+    """Test the dimensions of action embeddings."""
+    actions = jnp.array([0, 1, 2])  # Sample valid actions
+    embeddings = jax.vmap(network.action_embedding)(actions)
+    assert embeddings.shape == (3, 32)
+
+
+def test_forward_pass_dimensions():
+    key = jax.random.PRNGKey(0)
+    network = AwaleNetwork(key)
+
+    sample_game_state = jnp.array(
+        [4, 1, 3, 3, 4, 4, 0, 4, 4, 1, 3, 0], dtype=jnp.int32
+    )  # 12 pits + 2 scores
+    sample_score = jnp.array([0, 0], dtype=jnp.int32)
+    valid_actions = jnp.array([0, 1, 2])  # 3 valid actions
+
+    output = network(sample_game_state, valid_actions, sample_score)
+    print(type(output.shape))
+    assert output.shape == (3,)
+
+
+def test_empty_valid_actions(network, sample_game_state, sample_score):
+    """Test handling of empty valid actions list."""
+    valid_actions = jnp.array([])
+    output = network(sample_game_state, valid_actions, sample_score)
+    assert len(output) == 0
+
+
+def test_single_valid_action(network, sample_game_state, sample_score):
+    """Test handling of single valid action."""
+    valid_actions = jnp.array([0])
+    output = network(sample_game_state, valid_actions, sample_score)
+    assert output.shape == (1,)
+
+
+def test_all_valid_actions(network, sample_game_state, sample_score):
+    """Test handling of all possible actions."""
+    valid_actions = jnp.arange(12)  # All 12 possible actions
+    output = network(sample_game_state, valid_actions, sample_score)
+    assert output.shape == (12,)
+
+
+@pytest.mark.parametrize(
+    "game_state,valid_actions,expected_shape",
+    [
+        (jnp.zeros(12), jnp.array([0, 1]), (2,)),
+        (jnp.ones(12), jnp.array([0]), (1,)),
+        (jnp.full(12, 2), jnp.arange(6), (6,)),
+    ],
+)
+def test_various_inputs(
+    network, game_state, valid_actions, expected_shape, sample_score
+):
+    """Test network with various input combinations."""
+    output = network(game_state, valid_actions, sample_score)
+    assert output.shape == expected_shape
+
+
+def test_network_gradients():
+    """Test that gradients can be computed through the network."""
+    key = jax.random.PRNGKey(0)
+    network = AwaleNetwork(key)
+    game_state = jnp.ones(12)
+    valid_actions = jnp.array([0, 1, 2])
+    score = jnp.array([0, 0])
+
+    def loss_fn(network):
+        output = network(game_state, valid_actions, score)
+        return jnp.mean(output)
+
+    # Compute gradients
+    grad_fn = jax.grad(loss_fn)
+    grads = grad_fn(network)
+
+    # Check that gradients exist and are not None
+    assert grads is not None
+    # Check that gradients are not all zero
+    flat_grads = jax.tree_util.tree_leaves(grads)
+    assert any(jnp.any(g != 0) for g in flat_grads)
+
+
+def test_network_jit():
+    """Test that the network can be JIT-compiled."""
+    key = jax.random.PRNGKey(0)
+    network = AwaleNetwork(key)
+    game_state = jnp.ones(12)
+    valid_actions = jnp.array([0, 1, 2])
+    score = jnp.array([0, 0])
+
+    @jax.jit
+    def forward(network, state, actions, score):
+        return network(state, actions, score)
+
+    # This should not raise any errors
+    output = forward(network, game_state, valid_actions, score)
+    assert output.shape == (3,)
+
+
+def test_numerical_stability(network, sample_game_state, sample_score):
+    """Test network behavior with extreme input values."""
+    # Test with very large values
+    large_state = jnp.full(12, 1e5)
+    valid_actions = jnp.array([0, 1])
+    large_score = jnp.array([1e5, 1e5])
+    output_large = network(large_state, valid_actions, large_score)
+    assert jnp.all(jnp.isfinite(output_large))
+
+    # Test with very small values
+    small_state = jnp.full(12, 1e-5)
+    small_score = jnp.array([1e-5, 1e-5])
+    output_small = network(small_state, valid_actions, small_score)
+    assert jnp.all(jnp.isfinite(output_small))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -41,7 +41,7 @@ def test_distribute_seeds():
 
     new_board, last_pit = distribute_seeds(board, current_pit, seeds)
     expected = jnp.array([0, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4], dtype=jnp.int8)
-    assert (new_board == expected).all()
+    assert jnp.array_equal(new_board, expected)
     assert last_pit == 4
 
 
@@ -87,7 +87,7 @@ def test_update_game_state_switch_player():
     (new_board, new_scores, done, winner) = update_game_state(
         board, scores, current_player
     )
-    assert done == False
+    assert not done
     assert winner == 1
     assert jnp.array_equal(new_board, board)
 


### PR DESCRIPTION
The changes in this commit include the implementation of the AwaleNetwork model using the Equinox library. The key changes are:

1. Defining the AwaleNetwork class that inherits from the Equinox Module.
2. Implementing the state encoder, action embedding, and the final combine layers within the AwaleNetwork class.
3. Adding a helper function `init_network` to initialize the network with default parameters.
4. Removing unused imports and code from the `awale/env.py` file.
5. Adding a new reference to the Equinox documentation in the README.md file.
6. Adding a new test suite for the AwaleNetwork model in the `test/test_model.py` file.

These changes aim to provide a modular and flexible implementation of the AwaleNetwork model, making it easier to experiment with different network architectures and training approaches for the Awale game.